### PR TITLE
Improve performance

### DIFF
--- a/source/progress/bar.d
+++ b/source/progress/bar.d
@@ -4,7 +4,7 @@ import progress;
 
 static import std.algorithm;
 import std.array : back, join;
-import std.conv : to;
+import std.conv : to, text;
 import std.format : format;
 
 class Bar : Progress
@@ -25,7 +25,7 @@ class Bar : Progress
         fill = "#";
         hide_cursor = true;
         this.message = { return ""; };
-        this.suffix = { return format("%s/%s", this.index, this.max); };
+        this.suffix = { return format!"%s/%s"(this.index, this.max); };
         if (hide_cursor)
             file.write(HIDE_CURSOR);
     }
@@ -37,9 +37,8 @@ class Bar : Progress
         string message = this.message();
         string bar = repeat(this.fill, filled_length);
         string empty = repeat(this.empty_fill, empty_length);
-        string suffix = this.suffix();
-        string line = [message, this.bar_prefix, bar, empty, this.bar_suffix, suffix].join("");
-        this.writeln(line);
+        string suffix_ = this.suffix();
+        this.writeln(message, this.bar_prefix, bar, empty, this.bar_suffix, suffix_);
     }
 }
 
@@ -52,7 +51,7 @@ class ChargingBar : Bar
         bar_suffix = " ";
         empty_fill = "∙";
         fill = "█";
-        suffix = { return this.percent.to!string() ~ "%"; };
+        suffix = { return text(this.percent, '%'); };
     }
 }
 
@@ -97,10 +96,8 @@ class IncrementalBar : Bar
         string bar = repeat(phases.back, filled_length);
         string current = (phase <= nphases) ? this.phases[phase] : "";
         string empty = repeat(this.empty_fill, std.algorithm.max(0, empty_length));
-        string suffix = this.suffix();
-        string line = [message, this.bar_prefix, bar, current, empty, this.bar_suffix, suffix].join(
-                "");
-        this.writeln(line);
+        string suffix_ = this.suffix();
+        this.writeln(message, this.bar_prefix, bar, current, empty, this.bar_suffix, suffix_);
     }
 }
 

--- a/source/progress/package.d
+++ b/source/progress/package.d
@@ -7,8 +7,10 @@ public import progress.counter;
 public import progress.spinner;
 
 static import std.algorithm;
+import std.array : uninitializedArray;
 import std.concurrency : Generator, yield;
 import std.conv : to;
+import std.exception : assumeUnique;
 import std.math : ceil;
 import std.range.primitives : walkLength;
 import std.range : ElementType, isInfinite, isInputRange;
@@ -190,12 +192,13 @@ class Progress : Infinite
     }
 }
 
-package string repeat(string s, size_t n)
+package string repeat(string s, size_t n) pure nothrow @trusted
 {
-    string result;
-    foreach (i; 0 .. n)
+    immutable len = s.length;
+    auto buffer = uninitializedArray!(char[])(len * n);
+    for (size_t i, pos; i < n; i++, pos += len)
     {
-        result ~= s;
+        buffer[pos .. pos + len] = s[];
     }
-    return result;
+    return assumeUnique(buffer);
 }

--- a/source/progress/package.d
+++ b/source/progress/package.d
@@ -47,9 +47,31 @@ private:
 
 protected:
     alias file = stderr;
+    void writeln(string[] s...)
+    {
+        import std.array : Appender;
+
+        static Appender!string buffer;
+        buffer.clear();
+
+        buffer.put(LINEFEED ~ ERASE_IN_LINE);
+        foreach (_; 0 .. _height)
+        {
+            buffer.put(CURSOR_UP ~ ERASE_IN_LINE);
+        }
+        size_t tempHeight = 0;
+        foreach (t; s)
+        {
+            buffer.put(t);
+            tempHeight = std.algorithm.count(t, '\n');
+        }
+        file.write(buffer.data);
+        _height = tempHeight;
+    }
+
     void writeln(string s)
     {
-        file.write(LINEFEED, ERASE_IN_LINE, repeat(CURSOR_UP ~ ERASE_IN_LINE, _height), s);
+        file.write(LINEFEED ~ ERASE_IN_LINE, repeat(CURSOR_UP ~ ERASE_IN_LINE, _height), s);
         _height = std.algorithm.count(s, "\n");
     }
 

--- a/source/progress/package.d
+++ b/source/progress/package.d
@@ -49,8 +49,7 @@ protected:
     alias file = stderr;
     void writeln(string s)
     {
-        file.write(LINEFEED ~ ERASE_IN_LINE, repeat(CURSOR_UP ~ ERASE_IN_LINE, _height));
-        file.write(s);
+        file.write(LINEFEED, ERASE_IN_LINE, repeat(CURSOR_UP ~ ERASE_IN_LINE, _height), s);
         _height = std.algorithm.count(s, "\n");
     }
 


### PR DESCRIPTION
モンテカルロ法などのシミュレーションでnextを100万回呼ぶような場合にちょっとオーバーヘッドがあったので、何か所かメモリ割り当てを減らしたりで最適化してみました。
手元では割とはっきり変化が見れたので、問題なければマージお願いできますでしょうか

あとはInfiniteの持つdtの配列を固定長のリングバッファ的な物に置き換えるとGC負荷減らせそうなんですが、実装ボリューム増えそうなので一旦見送りました。